### PR TITLE
Simplify GitHub Actions deployment of CARS projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bsv/cars-cli",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@bsv/cars-cli",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dependencies": {
                 "@bsv/sdk": "^1.4.19",
                 "@bsv/wallet-toolbox-client": "^1.2.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bsv/cars-cli",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "main": "dist/index.js",
     "type": "module",
     "bin": {


### PR DESCRIPTION
This PR adds an Actions deployment wizard to the project menu.

A user can now set up a deployment key, add it to GitHub, and easily push updates to their `master` branch that go live immediately and automatically.

No more fussing around with manual processes of private key generation, having to ping the backend oncewith the new key to register it, and manually compute the public key to add the project admin tto the list. It even writes `.github/workflows/deploy.yaml` for you if you want!